### PR TITLE
fix: v0.9.1 — fix encoding header raw non-ASCII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ Ogni voce passa a una sezione con numero di versione quando viene completata.
 
 ---
 
+## [0.9.1] — 2026-04-10
+
+### Corretto
+- **Encoding soggetti con byte UTF-8 grezzi**: aggiunto `_decode_header_raw_fallback()` — quando `compat32` produce U+FFFD per header con byte non-ASCII non-RFC2047 (es. `ü` come `\xc3\xbc` diretto), il parser legge i byte grezzi dell'header e decodifica come UTF-8 poi Windows-1252; si applica a tutti gli header (`Subject`, `From`, `To`, ecc.) e al dizionario `raw_headers`
+
+---
+
 ## [0.9.0] — 2026-04-10
 
 ### Aggiunto

--- a/backend/core/analysis/email_parser.py
+++ b/backend/core/analysis/email_parser.py
@@ -120,6 +120,34 @@ def _decode_rfc2047(raw: str) -> str:
         return raw.strip()
 
 
+def _decode_header_raw_fallback(raw_email: bytes, header_name: str) -> str | None:
+    """Fallback per header con byte non-ASCII non codificati RFC 2047.
+
+    Cerca il valore dell'header nei byte grezzi e prova a decodificarlo
+    direttamente come UTF-8 o Windows-1252.
+    Restituisce None se l'header non è trovato.
+    """
+    pattern = re.compile(
+        rb"(?i)^" + re.escape(header_name.encode()) + rb":\s*(.*?)(?=\r?\n[^ \t]|\r?\n\r?\n|\Z)",
+        re.DOTALL | re.MULTILINE,
+    )
+    m = pattern.search(raw_email)
+    if not m:
+        return None
+    # Unfold: rimuove line folding (CRLF + spazio/tab)
+    value_bytes = re.sub(rb"\r?\n[ \t]+", b" ", m.group(1)).strip()
+    # Se contiene RFC 2047 encoded words, usa il decoder standard
+    if b"=?" in value_bytes:
+        return _decode_rfc2047(value_bytes.decode("ascii", errors="replace"))
+    # Prova decodifica diretta UTF-8, poi Windows-1252 (copre Latin-1 esteso)
+    for cs in ("utf-8", "windows-1252", "latin-1"):
+        try:
+            return value_bytes.decode(cs)
+        except (UnicodeDecodeError, LookupError):
+            continue
+    return value_bytes.decode("utf-8", errors="replace")
+
+
 def _extract_auth_results(values: list[str], keyword: str) -> str:
     """Extract pass/fail/none/neutral from the LAST Authentication-Results header."""
     if not values or not isinstance(values, list):
@@ -148,9 +176,19 @@ def _parse_eml(raw: bytes, filename: str) -> ParsedEmail:
 
     # --- Headers ---
     def get_header(name: str) -> str:
-        """Legge un header e decodifica gli encoded words RFC 2047."""
+        """Legge un header e decodifica gli encoded words RFC 2047.
+
+        Fallback ai byte grezzi se compat32 ha introdotto \\ufffd.
+        """
         val = msg.get(name, "")
-        return _decode_rfc2047(str(val)) if val else ""
+        if not val:
+            return ""
+        decoded = _decode_rfc2047(str(val))
+        if "\ufffd" in decoded:
+            fallback = _decode_header_raw_fallback(raw, name)
+            if fallback is not None and "\ufffd" not in fallback:
+                return fallback.strip()
+        return decoded
 
     def get_headers(name: str) -> list[str]:
         """Legge tutti i valori di un header (può essere presente più volte)."""
@@ -195,13 +233,18 @@ def _parse_eml(raw: bytes, filename: str) -> ParsedEmail:
         if m:
             parsed.spf_result = m.group(1).lower()
 
-    # All headers (lowercased keys) — recupera surrogate escapes da compat32
+    # All headers (lowercased keys) — recupera surrogate escapes da compat32,
+    # con fallback raw-bytes se compat32 ha prodotto \ufffd
     for key in msg.keys():
         raw_val = str(msg[key])
         try:
             raw_val = raw_val.encode("utf-8", errors="surrogateescape").decode("utf-8")
         except (UnicodeDecodeError, UnicodeEncodeError):
             pass
+        if "\ufffd" in raw_val:
+            fallback = _decode_header_raw_fallback(raw, key)
+            if fallback is not None and "\ufffd" not in fallback:
+                raw_val = fallback
         parsed.raw_headers[key.lower()] = raw_val
 
     # --- Body ---

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 class Settings(BaseSettings):
     # App
     APP_NAME: str = "EMLyzer"
-    VERSION: str = "0.9.0"
+    VERSION: str = "0.9.1"
     DEBUG: bool = False
 
     # CORS - backend in produzione + Vite dev server

--- a/claude.md
+++ b/claude.md
@@ -9,7 +9,7 @@ correcto un bug importante, o modificata l'architettura.
 ## Identità del progetto
 
 - **Nome**: EMLyzer
-- **Versione corrente**: 0.9.0 — fonte di verità: `backend/utils/config.py` → `VERSION`
+- **Versione corrente**: 0.9.1 — fonte di verità: `backend/utils/config.py` → `VERSION`
 - **Tipo**: piattaforma open-source di email threat analysis
 - **Filosofia**: nessuna dipendenza obbligatoria da API proprietarie; API a pagamento solo come plugin opzionali configurati dal singolo utente; analisi offline-first
 - **Repository**: GitHub (distribuzione pubblica)
@@ -146,7 +146,7 @@ upload file → parse_email_file()
 ### email_parser
 Supporta `.eml` (mail-parser) e `.msg` (extract-msg). Estrae tutti i campi in `ParsedEmail`:
 `filename, file_hash_md5/sha1/sha256, mail_from/to/cc/subject/date, message_id, return_path, reply_to, x_mailer, x_originating_ip, x_campaign_id, list_unsubscribe, received_chain, spf/dkim/dmarc_result, body_text, body_html, attachments, parse_errors`
-**Decodifica RFC 2047**: `get_header()` e `get_headers()` usano entrambi `_decode_rfc2047()` — decodificano automaticamente `=?UTF-8?Q?...?=`, `=?UTF-8?B?...?=` e `=?iso-8859-1?...?=` in tutti i campi header, inclusi quelli multi-valore. Il dizionario `raw_headers` applica surrogate-escape recovery per gestire i byte UTF-8 grezzi prodotti dalla policy compat32.
+**Decodifica RFC 2047**: `get_header()` e `get_headers()` usano entrambi `_decode_rfc2047()` — decodificano automaticamente `=?UTF-8?Q?...?=`, `=?UTF-8?B?...?=` e `=?iso-8859-1?...?=` in tutti i campi header, inclusi quelli multi-valore. Il dizionario `raw_headers` applica surrogate-escape recovery per gestire byte UTF-8 grezzi prodotti dalla policy compat32. **Fallback raw-bytes** (v0.9.1): quando compat32 produce U+FFFD (byte non-ASCII non-RFC2047, es. `ü` come `\xc3\xbc` diretto), `get_header()` e il loop `raw_headers` chiamano `_decode_header_raw_fallback(raw, name)` che estrae il valore dai byte grezzi del file e prova UTF-8 → Windows-1252.
 
 ### header_analyzer
 Funzioni interne: `_check_auth`, `_check_bulk_sender`, `_check_header_injection`, `_check_identity_mismatch`, `_check_missing_fields`, `_check_originating_ip`

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ Tutte le risposte sono in formato **JSON**. In caso di errore:
 Verifica che il server risponda.
 
 ```json
-{"status": "ok", "version": "0.9.0", "app": "EMLyzer"}
+{"status": "ok", "version": "0.9.1", "app": "EMLyzer"}
 ```
 
 ---
@@ -263,7 +263,7 @@ Configurazione corrente (lingua, plugin attivi, ecc.).
 ```json
 {
   "language": "it",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "max_upload_mb": 25,
   "reputation_plugins": {
     "abuseipdb": true,

--- a/start.bat
+++ b/start.bat
@@ -8,7 +8,7 @@ set "VENV_DIR=%~dp0.venv"
 set "VENV_PYTHON=%~dp0.venv\Scripts\python.exe"
 set "FOUND_PYTHON="
 set "FOUND_VER="
-set "VERSION=0.9.0"
+set "VERSION=0.9.1"
 
 :: ── Leggi versione da config.py usando Python (piu' affidabile di for/f) ──────
 :: Viene fatto dopo aver trovato Python, quindi piu' avanti nello script.


### PR DESCRIPTION
## Summary

- Aggiunta `_decode_header_raw_fallback()` in `email_parser.py`: quando `email.policy.compat32` produce U+FFFD per header con byte non-ASCII non-RFC2047 (es. `ü` = `\xc3\xbc` grezzo), il parser cerca i byte grezzi dell'header nel file originale e riprova la decodifica UTF-8 → Windows-1252
- Il fallback si attiva solo quando il risultato contiene `\ufffd` — nessun impatto sulle email normali
- Si applica a tutti gli header via `get_header()` e al dizionario `raw_headers`