### PR TITLE
fix: v0.9.2 — security dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ Ogni voce passa a una sezione con numero di versione quando viene completata.
 
 ---
 
+## [0.9.2] — 2026-04-11
+
+### Sicurezza
+- **urllib3 2.5.0 → 2.6.0**: fix CVE unbounded decompression chain e streaming decompression DoS (CWE-409); la libreria è dipendenza transitiva di `requests` usato nei connettori reputazione
+- **vite ^8.0.1 → ^8.0.5**: fix CVE `server.fs.deny` bypass e `.map` traversal nel dev server (impatto solo sviluppo, non produzione)
+- **axios**: analizzato — NON vulnerabile nel contesto EMLyzer (uso browser-only, `NO_PROXY` è variabile Node.js non applicabile al browser)
+
+---
+
 ## [0.9.1] — 2026-04-10
 
 ### Corretto

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ tldextract==5.3.1
 dnspython==2.8.0
 python-whois==0.9.6
 requests==2.33.0
-urllib3==2.5.0
+urllib3==2.6.0
 
 # File type detection (pure Python, no libmagic)
 filetype==1.2.0

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 class Settings(BaseSettings):
     # App
     APP_NAME: str = "EMLyzer"
-    VERSION: str = "0.9.1"
+    VERSION: str = "0.9.2"
     DEBUG: bool = False
 
     # CORS - backend in produzione + Vite dev server

--- a/claude.md
+++ b/claude.md
@@ -9,7 +9,7 @@ correcto un bug importante, o modificata l'architettura.
 ## Identità del progetto
 
 - **Nome**: EMLyzer
-- **Versione corrente**: 0.9.1 — fonte di verità: `backend/utils/config.py` → `VERSION`
+- **Versione corrente**: 0.9.2 — fonte di verità: `backend/utils/config.py` → `VERSION`
 - **Tipo**: piattaforma open-source di email threat analysis
 - **Filosofia**: nessuna dipendenza obbligatoria da API proprietarie; API a pagamento solo come plugin opzionali configurati dal singolo utente; analisi offline-first
 - **Repository**: GitHub (distribuzione pubblica)

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ Tutte le risposte sono in formato **JSON**. In caso di errore:
 Verifica che il server risponda.
 
 ```json
-{"status": "ok", "version": "0.9.1", "app": "EMLyzer"}
+{"status": "ok", "version": "0.9.2", "app": "EMLyzer"}
 ```
 
 ---
@@ -263,7 +263,7 @@ Configurazione corrente (lingua, plugin attivi, ecc.).
 ```json
 {
   "language": "it",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "max_upload_mb": 25,
   "reputation_plugins": {
     "abuseipdb": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,6 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.5"
   }
 }

--- a/start.bat
+++ b/start.bat
@@ -8,7 +8,7 @@ set "VENV_DIR=%~dp0.venv"
 set "VENV_PYTHON=%~dp0.venv\Scripts\python.exe"
 set "FOUND_PYTHON="
 set "FOUND_VER="
-set "VERSION=0.9.1"
+set "VERSION=0.9.2"
 
 :: ── Leggi versione da config.py usando Python (piu' affidabile di for/f) ──────
 :: Viene fatto dopo aver trovato Python, quindi piu' avanti nello script.


### PR DESCRIPTION
## Summary

- **urllib3 2.5.0 → 2.6.0**: fix due CVE di decompression DoS (unbounded Content-Encoding chain + streaming decompression ratio); dipendenza transitiva di `requests` usato nei connettori reputazione
- **vite ^8.0.1 → ^8.0.5**: fix `server.fs.deny` bypass e `.map` traversal nel dev server; impatto solo sviluppo, non produzione
- **axios**: analizzato e confermato NON vulnerabile — `NO_PROXY` bypass non si applica a uso browser-only