### PR TITLE
fix: v0.9.3 — security deps update (urllib3 2.6.3, axios 1.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ Ogni voce passa a una sezione con numero di versione quando viene completata.
 
 ---
 
+## [0.9.3] — 2026-04-11
+
+### Sicurezza
+- **urllib3 2.6.0 → 2.6.3**: fix CVE decompression-bomb bypass when following HTTP redirects (streaming API); versione 2.6.0 non sufficiente per questo alert
+- **axios ^1.13.6 → ^1.15.0**: fix due CVE CRITICAL (cloud metadata header injection + NO_PROXY SSRF); entrambe non applicabili nel contesto browser-only di EMLyzer, ma constraint aggiornato per chiudere gli alert GitHub
+
+---
+
 ## [0.9.2] — 2026-04-11
 
 ### Sicurezza

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ tldextract==5.3.1
 dnspython==2.8.0
 python-whois==0.9.6
 requests==2.33.0
-urllib3==2.6.0
+urllib3==2.6.3
 
 # File type detection (pure Python, no libmagic)
 filetype==1.2.0

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 class Settings(BaseSettings):
     # App
     APP_NAME: str = "EMLyzer"
-    VERSION: str = "0.9.2"
+    VERSION: str = "0.9.3"
     DEBUG: bool = False
 
     # CORS - backend in produzione + Vite dev server

--- a/claude.md
+++ b/claude.md
@@ -9,7 +9,7 @@ correcto un bug importante, o modificata l'architettura.
 ## Identità del progetto
 
 - **Nome**: EMLyzer
-- **Versione corrente**: 0.9.2 — fonte di verità: `backend/utils/config.py` → `VERSION`
+- **Versione corrente**: 0.9.3 — fonte di verità: `backend/utils/config.py` → `VERSION`
 - **Tipo**: piattaforma open-source di email threat analysis
 - **Filosofia**: nessuna dipendenza obbligatoria da API proprietarie; API a pagamento solo come plugin opzionali configurati dal singolo utente; analisi offline-first
 - **Repository**: GitHub (distribuzione pubblica)

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ Tutte le risposte sono in formato **JSON**. In caso di errore:
 Verifica che il server risponda.
 
 ```json
-{"status": "ok", "version": "0.9.2", "app": "EMLyzer"}
+{"status": "ok", "version": "0.9.3", "app": "EMLyzer"}
 ```
 
 ---
@@ -263,7 +263,7 @@ Configurazione corrente (lingua, plugin attivi, ecc.).
 ```json
 {
   "language": "it",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "max_upload_mb": 25,
   "reputation_plugins": {
     "abuseipdb": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "axios": "^1.13.6",
+    "axios": "^1.15.0",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/start.bat
+++ b/start.bat
@@ -8,7 +8,7 @@ set "VENV_DIR=%~dp0.venv"
 set "VENV_PYTHON=%~dp0.venv\Scripts\python.exe"
 set "FOUND_PYTHON="
 set "FOUND_VER="
-set "VERSION=0.9.2"
+set "VERSION=0.9.3"
 
 :: ── Leggi versione da config.py usando Python (piu' affidabile di for/f) ──────
 :: Viene fatto dopo aver trovato Python, quindi piu' avanti nello script.


### PR DESCRIPTION
## Summary

- **urllib3 2.6.0 → 2.6.3**: fix CVE redirect decompression-bomb bypass (alert #3 — la versione 2.6.0 non era sufficiente)
- **axios ^1.13.6 → ^1.15.0**: fix due CVE CRITICAL (cloud metadata header injection + NO_PROXY SSRF); entrambe non applicabili nell'uso browser-only di EMLyzer, ma constraint aggiornato per chiudere gli alert #8 / #9