### PR TITLE
fix: v0.10.2 — aggiornamento dipendenze di sicurezza (Dependabot #10 #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ Ogni voce passa a una sezione con numero di versione quando viene completata.
 
 ---
 
+## [0.10.2] — 2026-04-14
+
+### Sicurezza
+- **pytest aggiornato a 9.0.3** (da 9.0.2): fix privilege escalation su UNIX via directory `/tmp/pytest-of-{user}` con permessi scrivibili da altri utenti locali (Dependabot alert #10, GHSA-jfh8-c2jp-jmjq)
+- **follow-redirects aggiornato a 1.16.0** (da 1.15.11): fix leak di header di autenticazione personalizzati verso host cross-domain durante redirect HTTP; dipendenza transitiva di axios nel frontend (Dependabot alert #11, CVE-2025-46566)
+
+---
+
 ## [0.10.1] — 2026-04-13
 
 ### Corretto

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Email (.eml / .msg / testo incollato)
 
 ## 🔧 Versione
 
-**v0.10.1** — Python 3.11–3.13, 94 test automatici, Windows + Linux
+**v0.10.2** — Python 3.11–3.13, 94 test automatici, Windows + Linux
 
 ---
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,7 +37,7 @@ bleach==6.3.0
 tinycss2>=1.3.0
 
 # Dev & test
-pytest==9.0.2
+pytest==9.0.3
 pytest-asyncio==1.3.0
 httpx==0.28.1
 

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 class Settings(BaseSettings):
     # App
     APP_NAME: str = "EMLyzer"
-    VERSION: str = "0.10.1"
+    VERSION: str = "0.10.2"
     DEBUG: bool = False
 
     # CORS - backend in produzione + Vite dev server

--- a/claude.md
+++ b/claude.md
@@ -9,7 +9,7 @@ correcto un bug importante, o modificata l'architettura.
 ## Identità del progetto
 
 - **Nome**: EMLyzer
-- **Versione corrente**: 0.10.1 — fonte di verità: `backend/utils/config.py` → `VERSION`
+- **Versione corrente**: 0.10.2 — fonte di verità: `backend/utils/config.py` → `VERSION`
 - **Tipo**: piattaforma open-source di email threat analysis
 - **Filosofia**: nessuna dipendenza obbligatoria da API proprietarie; API a pagamento solo come plugin opzionali configurati dal singolo utente; analisi offline-first
 - **Repository**: GitHub (distribuzione pubblica)

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ Tutte le risposte sono in formato **JSON**. In caso di errore:
 Verifica che il server risponda.
 
 ```json
-{"status": "ok", "version": "0.10.1", "app": "EMLyzer"}
+{"status": "ok", "version": "0.10.2", "app": "EMLyzer"}
 ```
 
 ---
@@ -263,7 +263,7 @@ Configurazione corrente (lingua, plugin attivi, ecc.).
 ```json
 {
   "language": "it",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "max_upload_mb": 25,
   "reputation_plugins": {
     "abuseipdb": true,

--- a/docs/INSTALLAZIONE.md
+++ b/docs/INSTALLAZIONE.md
@@ -119,7 +119,7 @@ Se hai ricevuto il file come `.tar.gz`:
 
 **Linux / macOS:**
 ```bash
-tar -xzf EMLyzer_v0.10.1.tar.gz
+tar -xzf EMLyzer_v0.10.2.tar.gz
 cd EMLyzer
 ```
 
@@ -146,7 +146,7 @@ Si aprirà una finestra nera (il Prompt dei comandi) che mostrerà i progressi:
 
 ```
 ============================================
-  EMLyzer v0.10.1
+  EMLyzer v0.10.2
 ============================================
 
 [INFO] Python trovato:
@@ -216,7 +216,7 @@ Per verificare che il backend risponda correttamente, puoi anche aprire:
 
 Dovresti vedere la risposta JSON:
 ```json
-{"status": "ok", "version": "0.10.1", "app": "EMLyzer"}
+{"status": "ok", "version": "0.10.2", "app": "EMLyzer"}
 ```
 
 ---

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,9 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "vite": "^8.0.5"
+      },
+      "overrides": {
+        "follow-redirects": "1.16.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -998,7 +1001,7 @@
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -1618,9 +1621,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,9 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.2"
   },
+  "overrides": {
+    "follow-redirects": "1.16.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@types/react": "^19.2.14",

--- a/start.bat
+++ b/start.bat
@@ -8,7 +8,7 @@ set "VENV_DIR=%~dp0.venv"
 set "VENV_PYTHON=%~dp0.venv\Scripts\python.exe"
 set "FOUND_PYTHON="
 set "FOUND_VER="
-set "VERSION=0.10.1"
+set "VERSION=0.10.2"
 
 :: ── Leggi versione da config.py usando Python (piu' affidabile di for/f) ──────
 :: Viene fatto dopo aver trovato Python, quindi piu' avanti nello script.


### PR DESCRIPTION
## Summary

- **pytest 9.0.2 → 9.0.3**: fix privilege escalation su UNIX via directory `/tmp/pytest-of-{user}` con permessi scrivibili da altri utenti locali (Dependabot alert #10, GHSA-jfh8-c2jp-jmjq)
- **follow-redirects 1.15.11 → 1.16.0**: fix leak di header di autenticazione personalizzati verso host cross-domain durante redirect HTTP; dipendenza transitiva di axios nel frontend (Dependabot alert #11, CVE-2025-46566)
- Aggiornati `frontend/package.json` (overrides), `frontend/package-lock.json`, `backend/requirements.txt`

## Compatibilità

Nessuna modifica al codice applicativo.