### PR TITLE
docs: Update version references and cleanup roadmap for v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,34 +9,6 @@ Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.0.0/).
 
 Questa sezione raccoglie tutto ciò che è pianificato ma non ancora implementato.
 Le funzionalità sono ordinate per priorità di implementazione.
-Ogni voce passa a una sezione con numero di versione quando viene completata.
-
-### Reputazione — nuovi servizi (priorità alta)
-
-- [x] **CIRCL Passive DNS** — storico risoluzione DNS per IP e domini; gratuito con registrazione *(v0.11.0)*
-- [x] **GreyNoise Community** — distingue scanner innocui da attori malevoli, riduce falsi positivi; free tier 100 req/g *(v0.12.0)*
-- [x] **URLScan.io** — analisi completa URL con screenshot; free tier 100 req/h *(v0.12.0)*
-- [x] **Pulsedive** — threat intel aggregata su IP/URL/domini; free tier 30 req/min *(v0.12.0)*
-- [x] **Criminal IP** — threat score IP con geolocalizzazione; free tier *(v0.12.0)*
-- [x] **SecurityTrails** — DNS attuale e storico per domini; 50 req/mese free *(v0.12.0)*
-- [x] **Hybrid Analysis** — analisi statica avanzata hash allegati; gratuito con registrazione *(v0.12.0)*
-
-### Header analysis (priorità media)
-
-- [x] **List-Unsubscribe** — analisi link di unsubscribe (dominio diverso dal mittente, URL sospetti) *(v0.13.0)*
-- [x] **X-Campaign-ID** — analisi del campo già estratto: correlazione campagne bulk, pattern sospetti *(v0.13.0)*
-- [x] **ARC chain** (Authenticated Received Chain) — rilevante per phishing via account compromessi e forwarding *(v0.13.0)*
-
-### Body analysis (priorità media)
-
-- [x] **Rilevamento errori grammaticali** — integrazione LanguageTool (locale o API) per testi tradotti/generati automaticamente *(v0.14.0)*
-- [x] **Logistic regression NLP** — miglioramento classificatore attuale (Naive Bayes); migliore calibrazione probabilità *(v0.14.0)*
-- [x] **Dataset Enron/Nazario** — riaddestramento modello NLP con dataset pubblici per migliorare la generalizzazione *(v0.14.0)*
-- [x] **Omoglifi e Unicode spoofing** — rilevamento caratteri Unicode visivamente identici a caratteri latini nel testo (es. `а` cirillica) *(v0.14.0)*
-
-### Report (priorità media)
-
-- [x] **Sezione Campagne nel .docx** — la sezione Campagne Rilevate esiste nella UI e ora viene inclusa nel report Word generato *(v0.13.0)*
 
 ### Infrastruttura (priorità bassa)
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Email (.eml / .msg / testo incollato)
 
 ## 🔧 Versione
 
-**v0.14.2** — Python 3.11–3.13, 119 test automatici, Windows + Linux, code review & error handling fixes
+**v0.14.3** — Python 3.11–3.13, 119 test automatici, Windows + Linux, rilevamento phishing portoghese, supporto email HTML-only, evidence visibility
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ Tutte le risposte sono in formato **JSON**. In caso di errore:
 Verifica che il server risponda.
 
 ```json
-{"status": "ok", "version": "0.14.2", "app": "EMLyzer"}
+{"status": "ok", "version": "0.14.3", "app": "EMLyzer"}
 ```
 
 ---
@@ -263,7 +263,7 @@ Configurazione corrente (lingua, plugin attivi, ecc.).
 ```json
 {
   "language": "it",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "max_upload_mb": 25,
   "reputation_plugins": {
     "abuseipdb": true,

--- a/docs/INSTALLAZIONE.md
+++ b/docs/INSTALLAZIONE.md
@@ -117,7 +117,7 @@ Se hai ricevuto il file come `.tar.gz`:
 
 **Linux / macOS:**
 ```bash
-tar -xzf EMLyzer_v0.14.2.tar.gz
+tar -xzf EMLyzer_v0.14.3.tar.gz
 cd EMLyzer
 ```
 
@@ -144,7 +144,7 @@ Si aprirà una finestra nera (il Prompt dei comandi) che mostrerà i progressi:
 
 ```
 ============================================
-  EMLyzer v0.14.2
+  EMLyzer v0.14.3
 ============================================
 
 [INFO] Python trovato:
@@ -214,7 +214,7 @@ Per verificare che il backend risponda correttamente, puoi anche aprire:
 
 Dovresti vedere la risposta JSON:
 ```json
-{"status": "ok", "version": "0.14.1", "app": "EMLyzer"}
+{"status": "ok", "version": "0.14.3", "app": "EMLyzer"}
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Update CHANGELOG: remove completed items from [Unreleased] roadmap
- Update all version references: 0.14.2 → 0.14.3
  - README.md: version and feature description
  - docs/API.md: example responses
  - docs/INSTALLAZIONE.md: release archive name and setup output
- Cleanup [Unreleased] section: keep only infrastructure items

## Test plan
- All 119 tests pass
- Documentation updated consistently across all files