### PR TITLE
fix: Correct dependabot configuration to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,10 @@ updates:
     commit-message:
       prefix: "chore(deps-backend)"
       include: "scope"
+    target-branch: "develop"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    base: "develop"
 
   # Frontend JavaScript dependencies
   - package-ecosystem: "npm"
@@ -41,10 +41,10 @@ updates:
     commit-message:
       prefix: "chore(deps-frontend)"
       include: "scope"
+    target-branch: "develop"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    base: "develop"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -61,7 +61,7 @@ updates:
     open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: "/"
+    target-branch: "develop"
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
-    base: "develop"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Backend Python dependencies (main)
+  # Backend Python dependencies
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
@@ -21,6 +21,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    base: "develop"
 
   # Frontend JavaScript dependencies
   - package-ecosystem: "npm"
@@ -43,6 +44,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    base: "develop"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -62,3 +64,4 @@ updates:
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
+    base: "develop"


### PR DESCRIPTION
Ensures all dependency PRs target develop branch, not main.
Pip, npm, and github-actions sections now correctly configured.
