### PR TITLE
chore: sync main with develop - include frontend dependency updates

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,15 +3,14 @@
 # Versioni pinnate per riproducibilità
 
 # Web framework
-fastapi==0.136.3
+fastapi==0.137.0
 pydantic==2.13.4
-pydantic-core==2.46.4
-pydantic-settings==2.13.1
-uvicorn[standard]==0.42.0
+pydantic-settings==2.14.1
+uvicorn[standard]==0.49.0
 python-multipart==0.0.32
 
 # Email parsing
-mail-parser==4.1.4
+mail-parser==4.4.0
 extract-msg==0.55.0
 beautifulsoup4==4.13.5
 
@@ -29,7 +28,7 @@ filetype==1.2.0
 python-docx==1.2.0
 
 # Database (SQLAlchemy >= 2.0.36 richiesto per Python 3.13+)
-sqlalchemy==2.0.48
+sqlalchemy==2.0.50
 aiosqlite==0.22.1
 
 # Security / sanitization
@@ -37,8 +36,8 @@ bleach==6.4.0
 tinycss2>=1.3.0
 
 # Dev & test
-pytest==9.0.3
-pytest-asyncio==1.3.0
+pytest==9.1.0
+pytest-asyncio==1.4.0
 httpx==0.28.1
 
 # Language detection

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.15.1",
       "dependencies": {
-        "axios": "^1.17.0",
+        "axios": "^1.18.0",
         "lucide-react": "^1.18.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -1005,9 +1005,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.6.0",
         "vite": "^8.0.16"
       }
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
-      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.6.0",
     "vite": "^8.0.16"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "axios": "^1.17.0",
+    "axios": "^1.18.0",
     "lucide-react": "^1.18.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
## Summary

Synchronize main branch with develop to include all recent dependency updates from PR #103, #104, and the corrected PR #106.

## Changes

This PR brings main branch up-to-date with develop, which includes:
- PR #103: axios 1.17.0 → 1.18.0
- PR #104: eslint-plugin-react-refresh 0.5.2 → 0.5.3
- PR #106: Backend dependencies update (fastapi, pydantic-settings, uvicorn, mail-parser, sqlalchemy, pytest, pytest-asyncio)

## Test Status

✅ All tests passing on develop branch
✅ No conflicts expected
✅ Squash merge recommended to maintain clean history