### PR TITLE
fix: update version in start.bat to match config.py (0.16.0)

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -8,7 +8,7 @@ set "VENV_DIR=%~dp0.venv"
 set "VENV_PYTHON=%~dp0.venv\Scripts\python.exe"
 set "FOUND_PYTHON="
 set "FOUND_VER="
-set "VERSION=0.15.1"
+set "VERSION=0.16.0"
 
 :: ── Lingua output (it/en) — rilevata dalla locale di sistema ──────────────────
 :: Default: italiano. Se la lingua UI di Windows e' inglese, usa l'inglese.


### PR DESCRIPTION
Fix the hardcoded version number in start.bat that was displaying 0.15.1 instead of 0.16.0 to match the actual version in config.py.