### PR TITLE
chore: sync main with develop (dependency updates)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@
 # Versioni pinnate per riproducibilità
 
 # Web framework
-fastapi==0.138.0
+fastapi==0.139.0
 pydantic==2.13.4
 pydantic-settings==2.14.2
 uvicorn[standard]==0.49.0
@@ -12,7 +12,7 @@ python-multipart==0.0.32
 # Email parsing
 mail-parser==4.4.0
 python-oxmsg==0.0.2
-beautifulsoup4==4.14.0
+beautifulsoup4==4.15.0
 
 # Optional: RTF decompression for legacy .msg files (Outlook <2010)
 # Uncomment if you receive email from Outlook 97-2003 with RTF-only body:
@@ -38,13 +38,13 @@ aiosqlite==0.22.1
 # Security / sanitization
 bleach==6.4.0
 tinycss2>=1.3.0
-slowapi==0.1.9
+slowapi==0.1.10
 
 # Dev & test
 pytest==9.1.1
 pytest-asyncio==1.4.0
 httpx==0.28.1
-coverage==7.6.1
+coverage==7.14.3
 
 # Language detection
 langdetect==1.0.9


### PR DESCRIPTION
Sync main branch with develop.

## Changes
- Bump fastapi 0.138.0 → 0.139.0
- Bump beautifulsoup4 4.14.0 → 4.15.0
- Bump slowapi 0.1.9 → 0.1.10
- Bump coverage 7.6.1 → 7.14.3 (dev dependency)

All minor/patch version bumps, no breaking changes. 122/122 tests passing, verified locally before merge to develop.