### PR TITLE
chore(ci): add actions language to CodeQL scan matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,13 +6,13 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
-      - ".github/workflows/codeql.yml"
+      - ".github/workflows/**"
   pull_request:
     branches: [ main, develop ]
     paths:
       - "backend/**"
       - "frontend/**"
-      - ".github/workflows/codeql.yml"
+      - ".github/workflows/**"
 
 jobs:
   analyze:
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [python, javascript-typescript]
+        language: [python, javascript-typescript, actions]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
-      - ".github/workflows/tests.yml"
+      - ".github/workflows/**"
       - "pyproject.toml"
       - "package.json"
       - "package-lock.json"
@@ -15,7 +15,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
-      - ".github/workflows/tests.yml"
+      - ".github/workflows/**"
       - "pyproject.toml"
       - "package.json"
       - "package-lock.json"


### PR DESCRIPTION
## Summary
- Aggiunge `actions` alla matrice di scan di CodeQL (`.github/workflows/codeql.yml`), coprendo anche i file dei workflow GitHub Actions.
- La scansione automatica `language:actions` di GitHub (default setup) era ferma da metà aprile e non copriva più il repo. Ora viene eseguita nello stesso workflow custom insieme a python/javascript-typescript.
- Il trigger sui path passa da `.github/workflows/codeql.yml` a `.github/workflows/**`, così ogni modifica a un qualsiasi workflow innesca la scansione.

## Test plan
- [x] Verificata sintassi YAML e coerenza con gli step condizionali esistenti (il job `actions` salta gli step Python/Node)
- [ ] Verificare che il workflow CodeQL vada a buon fine su questo branch/PR