### PR TITLE
chore(ci): add least-privilege permissions to tests.yml jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
   backend-tests:
     name: Backend Tests (Python 3.13)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -79,6 +81,8 @@ jobs:
   frontend-lint-build:
     name: Frontend Lint & Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to both jobs in `tests.yml` (`backend-tests`, `frontend-lint-build`).
- Fixes CodeQL alerts #16 and #17 (`actions/missing-workflow-permissions`), surfaced by the new `Analyze (actions)` scan.
- Neither job needs more than read access to repo contents (checkout, run tests/build, upload artifacts).

## Test plan
- [x] Verify `Backend Tests (Python 3.13)` and `Frontend Lint & Build` still pass with the added permissions block