### PR TITLE
chore: sync main with develop (CodeQL actions permissions fix)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
   backend-tests:
     name: Backend Tests (Python 3.13)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -79,6 +81,8 @@ jobs:
   frontend-lint-build:
     name: Frontend Lint & Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to both jobs in `tests.yml`, closing CodeQL alerts #16 and #17 (`actions/missing-workflow-permissions`).

## Test plan
- [x] `Analyze (actions)`, `Analyze (python)`, `Analyze (javascript-typescript)`, `Backend Tests (Python 3.13)`, `Frontend Lint & Build` all passing on develop