### PR TITLE
fix(ci): prevent script injection in project-automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -32,6 +32,15 @@ jobs:
           # Configure GH_PROJECT_TOKEN with Projects write access.
           GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
 
@@ -128,11 +137,7 @@ jobs:
           }
 
           # Process based on event type
-          if [ "${{ github.event_name }}" = "issues" ]; then
-            ISSUE_NUM="${{ github.event.issue.number }}"
-            ISSUE_NODE_ID="${{ github.event.issue.node_id }}"
-            ISSUE_TITLE="${{ github.event.issue.title }}"
-
+          if [ "$EVENT_NAME" = "issues" ]; then
             echo "Processing Issue #$ISSUE_NUM..."
 
             # Assign
@@ -154,12 +159,8 @@ jobs:
               done <<< "$LABELS"
             fi
 
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_NUM="${{ github.event.pull_request.number }}"
-            PR_ACTION="${{ github.event.action }}"
-            PR_NODE_ID="${{ github.event.pull_request.node_id }}"
-            PR_TITLE="${{ github.event.pull_request.title }}"
-            PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_ACTION="$EVENT_ACTION"
 
             echo "Processing PR #$PR_NUM ($PR_ACTION) by @$PR_AUTHOR..."
 


### PR DESCRIPTION
## Summary
- Fixes GitHub code scanning alert #18 (`actions/code-injection/critical`) in `.github/workflows/project-automation.yml`
- Issue/PR titles and the PR author login were interpolated directly into the shell script via `${{ }}`, allowing a crafted title (e.g. containing `` `$(...)` ``) to execute arbitrary commands with access to the `GH_PROJECT_TOKEN` secret
- Values are now passed through step-level `env:` and referenced as shell variables (`$VAR`) instead, per GitHub's recommended mitigation

## Test plan
- [x] YAML syntax validated
- [x] Confirmed no remaining `${{ github.event.* }}` interpolations inside the `run:` script block
- [ ] Verify the code scanning alert closes automatically once merged